### PR TITLE
Implement caching for service account key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ dev: fmtcheck generate
 dev-dynamic: generate
 	@CGO_ENABLED=1 BUILD_TAGS='$(BUILD_TAGS)' VAULT_DEV_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
 
+devserver:
+	@sh -c "/opt/vault/bin/vault server -dev -dev-root-token-id=root -dev-plugin-dir=./bin"
+
 testcompile: fmtcheck generate
 	@for pkg in $(TEST) ; do \
 		go test -v -c -tags='$(BUILD_TAGS)' $$pkg -parallel=4 ; \

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -36,6 +36,8 @@ type backend struct {
 	iamResources iamutil.IamResourceParser
 
 	rolesetLock sync.Mutex
+
+	saCacheLock sync.Mutex
 }
 
 // Factory returns a new backend as logical.Backend.

--- a/plugin/iamutil/iam_resource_test.go
+++ b/plugin/iamutil/iam_resource_test.go
@@ -2,9 +2,10 @@ package iamutil
 
 import (
 	"encoding/json"
-	"github.com/hashicorp/go-gcp-common/gcputil"
 	"io/ioutil"
 	"testing"
+
+	"github.com/hashicorp/go-gcp-common/gcputil"
 )
 
 func TestParsedIamResource(t *testing.T) {
@@ -218,7 +219,7 @@ func TestConditionalIamResource(t *testing.T) {
 				Condition: &Condition{
 					Title:       "test",
 					Description: "",
-					Expression: "a==b",
+					Expression:  "a==b",
 				},
 			},
 			{

--- a/plugin/secrets_service_account_key.go
+++ b/plugin/secrets_service_account_key.go
@@ -381,7 +381,7 @@ func getCacheCollection(ctx context.Context, s logical.Storage, keyName string) 
 		return nil, err
 	}
 
-	if cachedKeyCollection != nil {
+	if cachedKeyCollection == nil {
 		return nil, nil
 	}
 


### PR DESCRIPTION
- Implement caching for service account key to overcome the limitation of 10 service account keys per roleset.