### PR TITLE
feat: Handle several failure cases

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -36,8 +36,6 @@ type backend struct {
 	resources iamutil.ResourceParser
 
 	rolesetLock sync.Mutex
-
-	saCacheLock sync.Mutex
 }
 
 // Factory returns a new backend as logical.Backend.
@@ -87,6 +85,11 @@ func Backend() *backend {
 		Invalidate:        b.invalidate,
 		WALRollback:       b.walRollback,
 		WALRollbackMinAge: 5 * time.Minute,
+
+		// Will be triggered every ~1m
+		PeriodicFunc: func(ctx context.Context, req *logical.Request) error {
+			return RunAllWorker(b, ctx, req)
+		},
 	}
 
 	return b

--- a/plugin/cache/serviceaccountkey/cache_collection.go
+++ b/plugin/cache/serviceaccountkey/cache_collection.go
@@ -1,0 +1,90 @@
+package serviceaccountkey
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+// CacheCollection is a collection of cached service account keys that belong to
+// the same roleset
+type CacheCollection struct {
+	// Mapping between SAK name and the cached SAK item
+	Items map[string]*CacheItem
+}
+
+// NewCacheCollection creates a new empty CacheCollection
+func NewCacheCollection() *CacheCollection {
+	cacheCollection := new(CacheCollection)
+	cacheCollection.Items = make(map[string]*CacheItem)
+
+	return cacheCollection
+}
+
+// PutItem adds a new fine addition to the SAK collection.
+//
+// Item key should be the SAK's name, in the format of:
+//   projects/<project_id>/serviceAccounts/vault<shorten_roleset_name>-<timestamp>@<project_id>.iam.gserviceaccount.com/keys/<key_id>
+// ... for example:
+// 	projects/infrastructure-260106/serviceAccounts/vaulttestproduct-te-1589452997@infrastructure-260106.iam.gserviceaccount.com/keys/471b62bd4b2ea968384f66c4d0fa8f91fbf4c61b
+func (c *CacheCollection) PutItem(itemKey string, item *CacheItem) error {
+	if itemKey == "" {
+		return errors.New("item key can't be empty")
+	}
+
+	if item == nil {
+		return errors.New("item can't be nil")
+	}
+
+	c.Items[itemKey] = item
+
+	return nil
+}
+
+// GetLatestItemByBindingHash returns the latest cached SAK that matches the binding hash,
+// according to:
+//   1. SA name, which should include timestamp (e.g. vaulttestproduct-te-1589452997)
+//   2. SAK issued timestamp
+func (c *CacheCollection) GetLatestItemByBindingHash(rsBindingHash string) (string, *CacheItem) {
+	keys := make([]string, 0, len(c.Items))
+	for k := range c.Items {
+		keys = append(keys, k)
+	}
+
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+
+	for _, key := range keys {
+		item := c.Items[key]
+
+		expiration := float64((*item).IssueTime.Unix()) + (*item).TTL.Seconds()
+		now := float64(time.Now().Unix())
+
+		if expiration > now && rsBindingHash == item.RolesetBindingHash {
+			return key, item
+		}
+	}
+
+	return "", nil
+}
+
+// PutToStorage persists the cache collection to Vault's storage
+func (c *CacheCollection) PutToStorage(ctx context.Context, s logical.Storage, collectionName string) error {
+	entry, err := logical.StorageEntryJSON(collectionName, c)
+	if err != nil {
+		return err
+	}
+
+	if err := s.Put(ctx, entry); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteItem deletes an entry from the collection
+func (c *CacheCollection) DeleteItem(keyName string) {
+	delete(c.Items, keyName)
+}

--- a/plugin/cache/serviceaccountkey/cache_item.go
+++ b/plugin/cache/serviceaccountkey/cache_item.go
@@ -1,0 +1,51 @@
+package serviceaccountkey
+
+import "time"
+
+// CacheItem is the service account key that is stored in or obtained from cache
+type CacheItem struct {
+	Name               string
+	RolesetName        string
+	RolesetBindingHash string
+	PrivateKeyData     string
+	KeyAlgorithm       string
+	KeyType            string
+	IssueTime          time.Time
+	TTL                time.Duration
+	Counter            int
+
+	// Different than TTL, which is the entry's TTL, LeaseFurthestExpiry is the
+	// estimation of the furthest expiration date of all leases that uses
+	// this SAK.
+	//
+	// Adding a positive offset is recommended since this not be earlier that any
+	// of the leases' expiration.
+	LeaseFurthestExpiry time.Time
+
+	// List of internal key IDs (which are a substitute for lease IDs) that once
+	// used this key but has been revoked. Used to prevent the same lease to
+	// decrement the reference counter more than once.
+	RevokedInternalKeyIDs []string
+}
+
+// SecretResponse returns Vault secret data. To be used with
+// backend.Secret(SecretTypeKey).Response(...)
+func (i *CacheItem) SecretResponse(keyID string) (
+	data map[string]interface{},
+	internal map[string]interface{},
+) {
+	data = map[string]interface{}{
+		"private_key_data": i.PrivateKeyData,
+		"key_algorithm":    i.KeyAlgorithm,
+		"key_type":         i.KeyType,
+	}
+
+	internal = map[string]interface{}{
+		"key_name":          i.Name,
+		"role_set":          i.RolesetName,
+		"role_set_bindings": i.RolesetBindingHash,
+		"key_internal_id":   keyID,
+	}
+
+	return
+}

--- a/plugin/cache/serviceaccountkey/service_account_key.go
+++ b/plugin/cache/serviceaccountkey/service_account_key.go
@@ -1,0 +1,347 @@
+package serviceaccountkey
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/api/iam/v1"
+)
+
+const (
+	// How long an SAK will stay in the cache, at the minimum. Please note that
+	// an SAK can stay in the cache for longer if it is still used by a lease
+	// which TTL is after the cache's TTL.
+	defaultCacheTTL = time.Duration(3) * time.Hour
+
+	// Storage path prefix for storing SAK cache
+	cacheSAKPathPrefix = "cache/sak"
+)
+
+var (
+	// All exported functions must use this mutex
+	saCacheLock sync.Mutex
+)
+
+// RevokeKey should be called by the plugin's revocation handler when revoking
+// an SAK. Returns true if the SAK is no longer referenced by any leases and
+// can be deleted from GCP.
+//
+// keyInternalID is required to prevent the same lease from decrementing the
+// counter multiple times. A "*" keyInternalID will decrement the counter
+// without checking.
+func RevokeKey(
+	ctx context.Context,
+	s logical.Storage,
+	rolesetName string,
+	keyName string,
+	keyInternalID string,
+) (shouldDelete bool, cacheItem *CacheItem, err error) {
+	saCacheLock.Lock()
+	defer saCacheLock.Unlock()
+
+	cacheCollection, err := getCacheCollection(ctx, s, rolesetName)
+	if err != nil {
+		return false, nil, fmt.Errorf("unable to get service account key cache collection of role %s: %v", rolesetName, err)
+	}
+
+	// Cache collection is missing, ...
+	if cacheCollection == nil {
+		return true, nil, nil
+	}
+
+	// ... or the key does not exist in it. The key should be deleted from GCP.
+	item, ok := cacheCollection.Items[keyName]
+	if !ok {
+		return true, nil, nil
+	}
+
+	// Make sure that the lease ID has not yet decremented the counter
+	if keyInternalID != "*" {
+		for _, revokedInternalKeyID := range item.RevokedInternalKeyIDs {
+			if revokedInternalKeyID == keyInternalID {
+				return item.Counter == 0, item, nil
+			}
+		}
+	}
+
+	// Decrement reference counter and persist the change
+	item.Counter--
+
+	// Append the key internal ID
+	if keyInternalID != "*" {
+		if item.RevokedInternalKeyIDs == nil {
+			item.RevokedInternalKeyIDs = []string{}
+		}
+
+		item.RevokedInternalKeyIDs = append(item.RevokedInternalKeyIDs, keyInternalID)
+	}
+
+	if item.Counter == 0 {
+		cacheCollection.DeleteItem(keyName)
+	}
+
+	cacheCollectionPath := fmt.Sprintf("%s/%s", cacheSAKPathPrefix, rolesetName)
+
+	if err := cacheCollection.PutToStorage(ctx, s, cacheCollectionPath); err != nil {
+		return false, nil, fmt.Errorf("unable to update the cache collection storage: %s", err.Error())
+	}
+
+	// The key should be deleted if the counter is zero
+	return item.Counter == 0, item, nil
+}
+
+// DeleteKey should only be called to forcefully delete a key from cache.
+func DeleteKey(
+	ctx context.Context,
+	s logical.Storage,
+	rolesetName string,
+	keyName string,
+) error {
+	saCacheLock.Lock()
+	defer saCacheLock.Unlock()
+
+	cacheCollection, err := getCacheCollection(ctx, s, rolesetName)
+	if err != nil {
+		return fmt.Errorf("unable to get service account key cache collection of role %s: %v", rolesetName, err)
+	}
+
+	// Cache collection is missing, ...
+	if cacheCollection == nil {
+		return nil
+	}
+
+	// ... or the key does not exist in it. The key should be deleted from GCP.
+	_, ok := cacheCollection.Items[keyName]
+	if !ok {
+		return nil
+	}
+
+	cacheCollection.DeleteItem(keyName)
+
+	cacheCollectionPath := fmt.Sprintf("%s/%s", cacheSAKPathPrefix, rolesetName)
+
+	if err := cacheCollection.PutToStorage(ctx, s, cacheCollectionPath); err != nil {
+		return fmt.Errorf("unable to update the cache collection storage: %s", err.Error())
+	}
+
+	// The key should be deleted if the counter is zero
+	return nil
+}
+
+// GetKeyByBindingHash fetches the latest SAK for a roleset from cache.
+//
+// Please note that if the value returned by this function is returned to Vault,
+// the UseKey() function must also be called.
+func GetKeyByBindingHash(
+	ctx context.Context,
+	s logical.Storage,
+	rolesetName string,
+	rolesetBindingHash string,
+) (key *CacheItem, err error) {
+	saCacheLock.Lock()
+	defer saCacheLock.Unlock()
+
+	cacheCollection, err := getCacheCollection(ctx, s, rolesetName)
+	if err != nil {
+		return nil, errwrap.Wrapf("could not get service account key cache collection: {{err}}", err)
+	}
+
+	if cacheCollection == nil {
+		return nil, nil
+	}
+
+	_, validCacheItem := cacheCollection.GetLatestItemByBindingHash(rolesetBindingHash)
+	if validCacheItem == nil {
+		return nil, nil
+	}
+
+	return validCacheItem, nil
+}
+
+// UseKey increments a cached SAK's reference counter. To be called when the key
+// is returned to Vault to be used in a lease.
+func UseKey(
+	ctx context.Context,
+	s logical.Storage,
+	rolesetName string,
+	keyName string,
+	leaseTTL time.Duration,
+) error {
+	saCacheLock.Lock()
+	defer saCacheLock.Unlock()
+
+	cacheCollection, err := getCacheCollection(ctx, s, rolesetName)
+	if err != nil {
+		return errwrap.Wrapf("could not get service account key cache collection: {{err}}", err)
+	}
+
+	if cacheCollection == nil {
+		return errors.New("cannot increment counter of a null cache collection")
+	}
+
+	cacheItem, ok := cacheCollection.Items[keyName]
+	if !ok {
+		return fmt.Errorf("cached SAK '%s' not found", keyName)
+	}
+
+	// Increment counter
+	cacheItem.Counter++
+
+	// Estimation of when the lease that uses this cached SAK will expire. The
+	// additional one minute is added to account for delay between when function
+	// was executed and when the lease will be assigned expiry by Vault.
+	leaseFurthestExpiry := time.Now().Add(leaseTTL).Add(time.Minute)
+	if cacheItem.LeaseFurthestExpiry.Before(leaseFurthestExpiry) {
+		cacheItem.LeaseFurthestExpiry = leaseFurthestExpiry
+	}
+
+	cacheCollectionPath := fmt.Sprintf("%s/%s", cacheSAKPathPrefix, rolesetName)
+
+	if err := cacheCollection.PutToStorage(ctx, s, cacheCollectionPath); err != nil {
+		return errwrap.Wrapf("failed to update cache key collection: {{err}}", err)
+	}
+
+	return nil
+}
+
+// UpsertToCacheCollection adds a new SAK to the cache collection of a roleset
+// and persists it to Vault storage.
+//
+// It is assumed that the new SAK will be used by a lease, and thus its
+// reference counter will be set to 1.
+func UpsertToCacheCollection(
+	ctx context.Context,
+	s logical.Storage,
+	rolesetName string,
+	rolesetBindingHash string,
+	key *iam.ServiceAccountKey,
+	cacheTTL time.Duration,
+	leaseTTL time.Duration,
+) error {
+	saCacheLock.Lock()
+	defer saCacheLock.Unlock()
+
+	now := time.Now()
+
+	if cacheTTL == 0 {
+		cacheTTL = defaultCacheTTL
+	}
+
+	// Estimation of when the lease that uses this cached SAK will expire. The
+	// additional one minute is added to account for delay between when function
+	// was executed and when the lease will be assigned expiry by Vault.
+	leaseFurthestExpiry := time.Now().Add(leaseTTL).Add(time.Minute)
+
+	newCacheItem := &CacheItem{
+		Name:                key.Name,
+		RolesetName:         rolesetName,
+		RolesetBindingHash:  rolesetBindingHash,
+		KeyAlgorithm:        key.KeyAlgorithm,
+		PrivateKeyData:      key.PrivateKeyData,
+		KeyType:             key.PrivateKeyType,
+		IssueTime:           now,
+		TTL:                 cacheTTL,
+		Counter:             1,
+		LeaseFurthestExpiry: leaseFurthestExpiry,
+	}
+
+	cacheCollection, err := getCacheCollection(ctx, s, rolesetName)
+	if err != nil {
+		return errwrap.Wrapf("failed to retrieve cache collection: {{err}}", err)
+	}
+
+	if cacheCollection == nil {
+		cacheCollection = NewCacheCollection()
+	}
+
+	if err := cacheCollection.PutItem(key.Name, newCacheItem); err != nil {
+		return errwrap.Wrapf("failed to put new item into cache collection: {{err}}", err)
+	}
+
+	cacheCollectionPath := fmt.Sprintf("%s/%s", cacheSAKPathPrefix, rolesetName)
+
+	if err := cacheCollection.PutToStorage(ctx, s, cacheCollectionPath); err != nil {
+		return errwrap.Wrapf("failed to insert new cache collection into storage: {{err}}", err)
+	}
+
+	return nil
+}
+
+// GetStaleEntries returns stale (i.e. expired) cache entries. Returns a map
+// of roleset names and lists of stale keys
+func GetStaleEntries(
+	ctx context.Context,
+	s logical.Storage,
+) (map[string][]*CacheItem, error) {
+	staleKeys := make(map[string][]*CacheItem)
+
+	rolesetNames, err := s.List(ctx, cacheSAKPathPrefix+"/")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rolesetName := range rolesetNames {
+		staleKeys[rolesetName] = []*CacheItem{}
+
+		cacheCollection, err := getCacheCollection(ctx, s, rolesetName)
+		if err != nil {
+			return nil, errwrap.Wrapf(
+				fmt.Sprintf("failed fetching cache collection for %s", rolesetName),
+				err,
+			)
+		}
+
+		for _, cachedKey := range cacheCollection.Items {
+			// The key is still used longer be used by any lease
+			if time.Now().Before(cachedKey.LeaseFurthestExpiry) {
+				continue
+			}
+
+			// The key has not expire yet
+			if time.Now().Before(cachedKey.IssueTime.Add(cachedKey.TTL)) {
+				continue
+			}
+
+			// The cached key is not used anymore and it has expired
+			staleKeys[rolesetName] = append(staleKeys[rolesetName], cachedKey)
+		}
+	}
+
+	return staleKeys, nil
+}
+
+// getCacheCollection retrieves cache collection for a specific roleset
+func getCacheCollection(
+	ctx context.Context,
+	s logical.Storage,
+	rolesetName string,
+) (*CacheCollection, error) {
+	cachedKeyCollection, err := s.Get(ctx, fmt.Sprintf("%s/%s", cacheSAKPathPrefix, rolesetName))
+	if err != nil {
+		return nil, err
+	}
+
+	// Old path convention, for backward compatibility
+	if cachedKeyCollection == nil {
+		cachedKeyCollection, err = s.Get(ctx, rolesetName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if cachedKeyCollection == nil {
+		return nil, nil
+	}
+
+	decodedCollection := new(CacheCollection)
+	if err := cachedKeyCollection.DecodeJSON(decodedCollection); err != nil {
+		return nil, err
+	}
+
+	return decodedCollection, nil
+}

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -21,6 +21,8 @@ const (
 	walTypeAccount    = "account"
 	walTypeAccountKey = "account_key"
 	walTypeIamPolicy  = "iam_policy"
+
+	walTypeAccountKeyCache = "account_key_cache"
 )
 
 func (b *backend) walRollback(ctx context.Context, req *logical.Request, kind string, data interface{}) error {
@@ -31,6 +33,8 @@ func (b *backend) walRollback(ctx context.Context, req *logical.Request, kind st
 		return b.serviceAccountKeyRollback(ctx, req, data)
 	case walTypeIamPolicy:
 		return b.serviceAccountPolicyRollback(ctx, req, data)
+	case walTypeAccountKeyCache:
+		return b.serviceAccountKeyCacheRollback(ctx, req, data)
 	default:
 		return fmt.Errorf("unknown type to rollback")
 	}

--- a/plugin/rollback_cache.go
+++ b/plugin/rollback_cache.go
@@ -1,0 +1,125 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/mitchellh/mapstructure"
+	"google.golang.org/api/iam/v1"
+
+	sakcache "github.com/hashicorp/vault-plugin-secrets-gcp/plugin/cache/serviceaccountkey"
+)
+
+// WAL entry for rolling back changes made into the SAK cache
+type walAccountKeyCache struct {
+	RoleSet string
+	KeyName string
+}
+
+// serviceAccountKeyCacheRollback rolls back changes made into the SAK cache.
+// Only to be used by backend.walRollback().
+func (b *backend) serviceAccountKeyCacheRollback(ctx context.Context, req *logical.Request, data interface{}) error {
+	b.rolesetLock.Lock()
+	defer b.rolesetLock.Unlock()
+
+	var entry walAccountKeyCache
+	if err := mapstructure.Decode(data, &entry); err != nil {
+		return err
+	}
+
+	err := sakcache.DeleteKey(ctx, req.Storage, entry.RoleSet, entry.KeyName)
+	if err != nil {
+		return errwrap.Wrapf(
+			fmt.Sprintf(
+				"unable to delete service account key '%s' from cache for roleset '%s': {{err}}",
+				entry.KeyName,
+				entry.RoleSet,
+			),
+			err,
+		)
+	}
+
+	b.Logger().Info(
+		"Service account key cache rolled back (WAL)",
+		"roleset", entry.RoleSet,
+		"key_name", entry.KeyName,
+	)
+
+	return nil
+}
+
+// rollbackCachedServiceAccountKey should be called on creation of a new SAK
+// when there are failures during cache-related operations.
+func rollbackCachedServiceAccountKey(
+	ctx context.Context,
+	s logical.Storage,
+	iamC *iam.Service,
+	rolesetName string,
+	keyName string,
+) error {
+	// WAL entries to retry this rollback in the background.
+	// Deletion of the cache entry for the SAK, due to errors in manual rollback
+	sakCacheRollbackWAL, errWAL := framework.PutWAL(ctx, s, walTypeAccountKeyCache, &walAccountKeyCache{
+		RoleSet: rolesetName,
+		KeyName: keyName,
+	})
+	if errWAL != nil {
+		tryDeleteWALs(ctx, s, sakCacheRollbackWAL)
+
+		return errwrap.Wrapf(
+			fmt.Sprintf(
+				"unable to create WAL entries for rolling back service account key %s (manual cleanup required)", keyName,
+			),
+			errWAL,
+		)
+	}
+
+	// Deletion of the newly-created SAK, due to errors in manual rollback
+	sakRollbackWAL, errWAL := framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
+		RoleSet:            rolesetName,
+		ServiceAccountName: "", // not needed if we have KeyName set
+		KeyName:            keyName,
+	})
+	if errWAL != nil {
+		tryDeleteWALs(ctx, s, sakRollbackWAL)
+
+		return errwrap.Wrapf(
+			fmt.Sprintf(
+				"unable to create WAL entries for rolling back service account key %s (manual cleanup required)", keyName,
+			),
+			errWAL,
+		)
+	}
+
+	// We can't assume that the SAK has not been successfully persisted into
+	// storage. Thus, delete the SAK from storage.
+	err := sakcache.DeleteKey(ctx, s, rolesetName, keyName)
+	if err != nil {
+		return errwrap.Wrapf(
+			fmt.Sprintf(
+				"unable to rollback cache entry for service account key %s (will be retried w/ WAL)", keyName,
+			),
+			errWAL,
+		)
+	}
+
+	tryDeleteWALs(ctx, s, sakCacheRollbackWAL)
+
+	// Delete the SAK from GCP
+	_, err = iamC.Projects.ServiceAccounts.Keys.Delete(keyName).Do()
+	if err != nil && !isGoogleAccountKeyNotFoundErr(err) {
+		return errwrap.Wrapf(
+			fmt.Sprintf(
+				"unable to rollback service account key %s (will be retried w/ WAL)", keyName,
+			),
+			errWAL,
+		)
+	}
+
+	tryDeleteWALs(ctx, s, sakRollbackWAL)
+
+	return nil
+}

--- a/plugin/util/key_id.go
+++ b/plugin/util/key_id.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+const keyIDlen = 16
+const keyIDchars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+// Initialize random for GenerateKeyID()
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// GenerateKeyID generates a key ID for SAK that will be returned by
+// backend.getSecretKey(), to identify each secret returned by the plugin.
+//
+// We need our own identifier since the plugin does not have access to lease IDs
+// during secret generation and revocation.
+func GenerateKeyID() string {
+	b := make([]byte, keyIDlen)
+
+	for i := range b {
+		b[i] = keyIDchars[rand.Intn(len(keyIDchars))]
+	}
+
+	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), b)
+}

--- a/plugin/worker.go
+++ b/plugin/worker.go
@@ -1,0 +1,49 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+type workerEntry struct {
+	name     string
+	runFunc  func(*backend, context.Context, *logical.Request) error
+	minDelay time.Duration
+	lastRun  time.Time
+}
+
+var workerEntries = []*workerEntry{
+	{
+		name:     "cachecleanup",
+		runFunc:  WorkerCleanUpStaleCacheEntries,
+		minDelay: 5 * time.Minute,
+	},
+}
+
+// RunAllWorker run all workers which lastRun is older than now-minDelay
+func RunAllWorker(b *backend, ctx context.Context, req *logical.Request) error {
+	b.Logger().Debug("Running workers...")
+
+	for _, worker := range workerEntries {
+		if !worker.lastRun.Before(time.Now().Add(-worker.minDelay)) {
+			continue
+		}
+
+		b.Logger().Debug(fmt.Sprintf("Running worker %s", worker.name))
+		worker.lastRun = time.Now()
+
+		if err := worker.runFunc(b, ctx, req); err != nil {
+			b.Logger().Error(
+				fmt.Sprintf("Error running worker %s", worker.name),
+				"err", err.Error(),
+			)
+		}
+	}
+
+	b.Logger().Debug("Finished running all workers")
+
+	return nil
+}

--- a/plugin/worker_cache_cleanup.go
+++ b/plugin/worker_cache_cleanup.go
@@ -1,0 +1,58 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/sdk/logical"
+
+	sakcache "github.com/hashicorp/vault-plugin-secrets-gcp/plugin/cache/serviceaccountkey"
+)
+
+// WorkerCleanUpStaleCacheEntries clean stale cache entries
+func WorkerCleanUpStaleCacheEntries(
+	b *backend,
+	ctx context.Context,
+	req *logical.Request,
+) error {
+	b.Logger().Debug("Cleaning up stale cache entries...")
+
+	allStaleKeys, err := sakcache.GetStaleEntries(ctx, req.Storage)
+	if err != nil {
+		return errwrap.Wrapf("failed getting stale SAK cache entries: {{err}}", err)
+	}
+
+	iamC, err := b.IAMAdminClient(req.Storage)
+	if err != nil {
+		return errwrap.Wrapf("failed to create IAM client: {{err}}", err)
+	}
+
+	var merr *multierror.Error
+	removed := 0
+	for rolesetName, staleKeys := range allStaleKeys {
+		if len(staleKeys) == 0 {
+			continue
+		}
+
+		for _, staleKey := range staleKeys {
+			err := rollbackCachedServiceAccountKey(ctx, req.Storage, iamC, rolesetName, staleKey.Name)
+			if err != nil {
+				// Ignore error for now
+				merr = multierror.Append(merr, err)
+			} else {
+				removed++
+				b.Logger().Debug(fmt.Sprintf("Cleaned up stale SAK %s from roleset %s", staleKey.Name, rolesetName))
+			}
+		}
+	}
+
+	if removed != 0 {
+		b.Logger().Info(fmt.Sprintf("Cleaned up %d stale entries from SAK cache", removed))
+	}
+
+	b.Logger().Debug("Finished cleaning up stale SAK cache entries")
+
+	return merr.ErrorOrNil()
+}


### PR DESCRIPTION
Behavioral changes:
  - Revoking key from cache will no longer throw an error if the key does not exist in the cache, thus can be retried.

  - Revocation of key from cache will keep track of leases that have revoked it.
    - This is done to prevent the same lease from decrementing the key's reference counter more than once, which can happen if there is an error after (or during) persisting the cache entries to Vault's storage.
    - However, since the plugin has no access to Vault's actual lease IDs, we generate our own internal key ID in the format of `<timestamp-ns>-<random-string>` to uniquely differentiate each `logical.Secret` returned to Vault.

  - Errors during rollback of SAK generation will now be retried using Vault's WAL mechanism.

  - Added periodical job (every ~1m) to clean up stale SAKs. A SAK is considered stale if it satisfies all the following conditions:
    - Should no longer used to generate new leases (indicated by `cachedKey.IssueTime + cachedKey.TTL` being earlier than `time.Now()`)
    - Should no longer used by any exising leases (indicated by `cachedKey.LeaseFurthestExpiry` being earlier than `time.Now()`). `cachedKey.LeaseFurthestExpiry` is updated to `time.Now() + leaseTTL` every time a new lease was generated using the key.

Refactor changes:
  - Moved cache-related logic to the `plugin/cache/serviceaccountkey` package
  - SAK cache mutex moved to the `plugin/cache/serviceaccountkey` package
  - Reference counter will no longer be automatically incremented when retrieving cached SAK. Use `UseKey()` to increment the counter.

Backward-compatible, but not forward-compatible changes:
  - On logical storage, SAK caches will be stored into `/cache/sak/<roleset-name>` (previously was `/<roleset-name>`). Fetching of existing cache entry will fallback to the old path convention if the new one does not exist.
