### PR TITLE
feat: Allow usage of static/existing service account in a roleset

### DIFF
--- a/plugin/cache/serviceaccountkey/cache_collection.go
+++ b/plugin/cache/serviceaccountkey/cache_collection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
@@ -31,6 +32,10 @@ func NewCacheCollection() *CacheCollection {
 // ... for example:
 // 	projects/infrastructure-260106/serviceAccounts/vaulttestproduct-te-1589452997@infrastructure-260106.iam.gserviceaccount.com/keys/471b62bd4b2ea968384f66c4d0fa8f91fbf4c61b
 func (c *CacheCollection) PutItem(itemKey string, item *CacheItem) error {
+	if len(strings.Split(itemKey, "/")) != 6 {
+		return errors.New("item key must be in the format of projects/<project_id>/serviceAccounts/<serviceaccount-email>/keys/<key_id>")
+	}
+
 	if itemKey == "" {
 		return errors.New("item key can't be empty")
 	}
@@ -68,6 +73,45 @@ func (c *CacheCollection) GetLatestItemByBindingHash(rsBindingHash string) (stri
 	}
 
 	return "", nil
+}
+
+// GetLatestItemByServiceAccountEmail returns the latest cached SAK name with
+// matching service account email
+func (c *CacheCollection) GetLatestItemByServiceAccountEmail(
+	serviceAccountEmail string,
+) (string, *CacheItem) {
+	var latestCachedKey *CacheItem = nil
+	var latestIssueTime time.Time = time.Time{}
+
+	for _, cachedKey := range c.Items {
+		// Key name is expected to be in the format of
+		// projects/<project_id>/serviceAccounts/<serviceaccount-email>/keys/<key_id>
+		keyNameSplit := strings.Split(cachedKey.Name, "/")
+		if len(keyNameSplit) != 6 {
+			// Silently ignore unexpected key names
+			continue
+		}
+
+		// Not match
+		cachedSAEmail := keyNameSplit[3]
+		if cachedSAEmail != serviceAccountEmail {
+			continue
+		}
+
+		laterThanTheLatest := cachedKey.IssueTime.After(latestIssueTime)
+		notYetExpired := cachedKey.IssueTime.Add(cachedKey.TTL).After(time.Now())
+
+		if laterThanTheLatest && notYetExpired {
+			latestCachedKey = cachedKey
+			latestIssueTime = cachedKey.IssueTime
+		}
+	}
+
+	if latestCachedKey == nil {
+		return "", nil
+	}
+
+	return latestCachedKey.Name, latestCachedKey
 }
 
 // PutToStorage persists the cache collection to Vault's storage

--- a/plugin/role_set.go
+++ b/plugin/role_set.go
@@ -55,7 +55,7 @@ func (rs *RoleSet) validate() error {
 
 	if rs.UseStaticServiceAccount {
 		if rs.AccountId.EmailOrId == "" || rs.AccountId.Project == "" {
-			err = multierror.Append(err, fmt.Errorf("role set should have service account & project associated"))
+			err = multierror.Append(err, fmt.Errorf("role set should have service account & project associated when using static service account"))
 		}
 
 		if len(rs.Bindings) != 0 {

--- a/plugin/role_set.go
+++ b/plugin/role_set.go
@@ -30,6 +30,8 @@ type RoleSet struct {
 	Name       string
 	SecretType string
 
+	UseStaticServiceAccount bool
+
 	RawBindings string
 	Bindings    ResourceBindings
 
@@ -51,12 +53,26 @@ func (rs *RoleSet) validate() error {
 		err = multierror.Append(err, fmt.Errorf("role set should have account associated"))
 	}
 
-	if len(rs.Bindings) == 0 {
-		err = multierror.Append(err, fmt.Errorf("role set bindings cannot be empty"))
-	}
+	if rs.UseStaticServiceAccount {
+		if rs.AccountId.EmailOrId == "" || rs.AccountId.Project == "" {
+			err = multierror.Append(err, fmt.Errorf("role set should have service account & project associated"))
+		}
 
-	if len(rs.RawBindings) == 0 {
-		err = multierror.Append(err, fmt.Errorf("role set raw bindings cannot be empty string"))
+		if len(rs.Bindings) != 0 {
+			err = multierror.Append(err, fmt.Errorf("role set bindings must be empty when using static service account"))
+		}
+
+		if len(rs.RawBindings) != 0 {
+			err = multierror.Append(err, fmt.Errorf("role set raw bindings must be empty string when using static service account"))
+		}
+	} else {
+		if len(rs.Bindings) == 0 {
+			err = multierror.Append(err, fmt.Errorf("role set bindings cannot be empty"))
+		}
+
+		if len(rs.RawBindings) == 0 {
+			err = multierror.Append(err, fmt.Errorf("role set raw bindings cannot be empty string"))
+		}
 	}
 
 	switch rs.SecretType {
@@ -126,6 +142,14 @@ type TokenGenerator struct {
 func (b *backend) saveRoleSetWithNewAccount(ctx context.Context, s logical.Storage, rs *RoleSet, project string, newBinds ResourceBindings, scopes []string) (warning []string, err error) {
 	b.rolesetLock.Lock()
 	defer b.rolesetLock.Unlock()
+
+	if rs.UseStaticServiceAccount {
+		return nil, fmt.Errorf(
+			"roleset '%s' is using an static service account, cannot "+
+				"save changes into a new service account",
+			rs.Name,
+		)
+	}
 
 	httpC, err := b.HTTPClient(s)
 	if err != nil {


### PR DESCRIPTION
# Overview
Allow the use of a static/existing GCP Service Account during creation of a roleset, instead of letting the plugin generate one "dynamically".

# Design of Change
A new parameter `static_service_account_email` for the [Write Config API](https://www.vaultproject.io/api/secret/gcp#write-config) was added, which when supplied with a service account email (e.g. `my-service-account@my-project-id.iam.gserviceaccount.com`), will be used as the service account to generate service account keys for during the [Generate Secret: Service Account Key API](https://www.vaultproject.io/api/secret/gcp#generate-secret-iam-service-account-creds-service-account-key) call.

Previously, all rolesets will use a new Service Account generated by the plugin during roleset (re)configuration.

Changes should be backward compatible.

# Related Issues/Pull Requests
[ ] Depends on [PR #4](https://github.com/cermati/vault-plugin-secrets-gcp/pull/4)
